### PR TITLE
create todo in tag todo list with this tag by default

### DIFF
--- a/src/entities/tag/utils/useTagById.tsx
+++ b/src/entities/tag/utils/useTagById.tsx
@@ -3,7 +3,7 @@ import {useSelector} from 'react-redux';
 import {userTagsSelector} from '@entities/tag/store/tagStore';
 
 
-const useTagById = (id: string | undefined): ITag=> {
+const useTagById = (id: string | undefined): ITag | undefined => {
   const userTags = useSelector(userTagsSelector)
   const index = userTags.findIndex((tag) => tag.id === id);
   return userTags[index]

--- a/src/entities/tag/utils/useTags.ts
+++ b/src/entities/tag/utils/useTags.ts
@@ -10,7 +10,7 @@ export const useTags = (formState: ITodo, doesTodoExist: boolean):
   const allTodos = useSelector(allTodosSelector)
 
   const existingTodoTags: tagIdType[] = allTodos.find((todo) => todo.id === formState.id)?.tags || []
-  const [creatingTodoTags, setCreatingTodoTags] = useState<tagIdType[]>([])
+  const [creatingTodoTags, setCreatingTodoTags] = useState<tagIdType[]>(formState.tags)
 
   const todoTags = doesTodoExist ? existingTodoTags: creatingTodoTags
 

--- a/src/entities/todos/components/TodoDetail/components/DetailsCard.tsx
+++ b/src/entities/todos/components/TodoDetail/components/DetailsCard.tsx
@@ -12,7 +12,7 @@ import {sendUpdatedTodo} from '@shared/api/services/todos';
 import InfoCard from '@entities/todos/components/TodoDetail/components/InfoCard';
 import {userIdSelector} from '@entities/user/model/store';
 import TagsPanel from '@entities/todos/components/TagsPanel';
-import {useTagById} from '@entities/tag';
+import {userTagsSelector} from '@entities/tag/store/tagStore';
 
 interface Props {
   todo: ITodo,
@@ -23,9 +23,11 @@ const DetailsCard = ({todo, onComplete}: Props) => {
   const {date, id} = todo
   const theme = useTheme()
   const userId = useSelector(userIdSelector)
+  const userTags = useSelector(userTagsSelector)
   const dispatch = useDispatch()
   const [todoDate, setTodoDate] = useTodoDate(date, id)
   const [priority, onSelected] = useSelectPriority(todo.priority)
+  const todoTags = userTags.filter((userTag) => todo.tags.includes(userTag.id))
 
   const onPriorityHandler = (event: SelectChangeEvent<Priority>) => {
     //@ts-ignore
@@ -35,8 +37,6 @@ const DetailsCard = ({todo, onComplete}: Props) => {
     sendUpdatedTodo(data, userId)
     dispatch(setPriority(data))
   }
-
-  const tags = todo.tags?.map(useTagById)
 
   const onDateSelect = (newDate: IDate) => {
     setTodoDate(newDate)
@@ -58,8 +58,8 @@ const DetailsCard = ({todo, onComplete}: Props) => {
             <DetailActionPanelItem label={'Set priority'}>
               <PriorityButton initialPriority={priority} changeHandler={onPriorityHandler} variant={'short'}/>
             </DetailActionPanelItem>
-            {tags?.length! > 0 && <DetailActionPanelItem label={'Tags'}>
-              <TagsPanel tags={tags}/>
+            {todo.tags.length! > 0 && <DetailActionPanelItem label={'Tags'}>
+              <TagsPanel tags={todoTags}/>
             </DetailActionPanelItem>}
           </Box>
         </Box>

--- a/src/features/addToFavorites/components/FavotitesList.tsx
+++ b/src/features/addToFavorites/components/FavotitesList.tsx
@@ -23,7 +23,7 @@ const FavoritesList = ({favorites}: {favorites: IFavorite[]}) => {
 const FavoriteItem = ({favorite}: {favorite: IFavorite}) => {
   const item = useTagById(favorite.itemId)
   const navigate = useNavigate()
-  const {deleteFromFavorites} = useToggleFavorite(item?.id)
+  const {deleteFromFavorites} = useToggleFavorite(item?.id!)
 
   const onDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()

--- a/src/features/todoFeatures/CreateTodo/components/createTodoForm.tsx
+++ b/src/features/todoFeatures/CreateTodo/components/createTodoForm.tsx
@@ -3,7 +3,7 @@ import {toast} from 'react-toastify';
 
 import BaseTodoForm from '@features/todoFeatures/components/baseTodoForm';
 import {addNewTask} from '@entities/todos/store/todo';
-import {ITag, ITodo} from '@shared/interfacesAndTypes';
+import {ITodo} from '@shared/interfacesAndTypes';
 import {postNewTodo} from '@shared/api/services/todos';
 import {userIdSelector} from '@entities/user/model/store';
 import TodoCreatedNotification from '@shared/components/Notification/TodoCreated';
@@ -15,9 +15,9 @@ interface Props {
 
 interface Props {
   onClose: () => void,
-  initialDate?: string,
-  initialProject?: string,
-  initialTag?: ITag['id'][],
+  initialDate?: ITodo['date'],
+  initialProject?: ITodo['projectId'],
+  initialTag?: ITodo['tags'],
 }
 
 const CreateTodoForm = ({onClose, initialDate, initialProject, initialTag}: Props) => {

--- a/src/features/todoFeatures/CreateTodo/components/createTodoForm.tsx
+++ b/src/features/todoFeatures/CreateTodo/components/createTodoForm.tsx
@@ -3,7 +3,7 @@ import {toast} from 'react-toastify';
 
 import BaseTodoForm from '@features/todoFeatures/components/baseTodoForm';
 import {addNewTask} from '@entities/todos/store/todo';
-import {ITodo} from '@shared/interfacesAndTypes';
+import {ITag, ITodo} from '@shared/interfacesAndTypes';
 import {postNewTodo} from '@shared/api/services/todos';
 import {userIdSelector} from '@entities/user/model/store';
 import TodoCreatedNotification from '@shared/components/Notification/TodoCreated';
@@ -16,10 +16,11 @@ interface Props {
 interface Props {
   onClose: () => void,
   initialDate?: string,
-  initialProject?: string
+  initialProject?: string,
+  initialTag?: ITag['id'][],
 }
 
-const CreateTodoForm = ({onClose, initialDate, initialProject}: Props) => {
+const CreateTodoForm = ({onClose, initialDate, initialProject, initialTag}: Props) => {
   const dispatch = useDispatch();
   const userId = useSelector(userIdSelector)
 
@@ -38,7 +39,11 @@ const CreateTodoForm = ({onClose, initialDate, initialProject}: Props) => {
     }
   };
 
-  return <BaseTodoForm onClose={onClose} onSubmit={onSubmit} initialDate={initialDate} todoProjectId={initialProject}/>
+  return <BaseTodoForm onClose={onClose}
+    onSubmit={onSubmit}
+    initialDate={initialDate}
+    initialTag={initialTag}
+    todoProjectId={initialProject}/>
 };
 
 export default CreateTodoForm;

--- a/src/features/todoFeatures/components/baseTodoForm.tsx
+++ b/src/features/todoFeatures/components/baseTodoForm.tsx
@@ -1,7 +1,7 @@
 import {useForm} from 'react-hook-form';
 import {Box, SelectChangeEvent} from '@mui/material';
 import {BaseFormInputs} from '@shared/forms/interfaces/interfaces';
-import {IDate, ITag, ITodo, Priority} from '@shared/interfacesAndTypes';
+import {IDate, ITodo, Priority} from '@shared/interfacesAndTypes';
 import {useTags} from '@entities/tag/utils/useTags';
 import TodoFormInputs from '@shared/forms/ui/Inputs';
 import FormActions from '@features/todoFeatures/components/setDataPanel';
@@ -19,7 +19,7 @@ interface Props {
   onSubmit: (newTodo: ITodo) => void,
   todo?: ITodo,
   initialDate?: string,
-  initialTag?:ITag['id'][],
+  initialTag?: ITodo['tags'],
   hideActions?: boolean,
   todoProjectId?: string
 }

--- a/src/features/todoFeatures/components/baseTodoForm.tsx
+++ b/src/features/todoFeatures/components/baseTodoForm.tsx
@@ -1,7 +1,7 @@
 import {useForm} from 'react-hook-form';
 import {Box, SelectChangeEvent} from '@mui/material';
 import {BaseFormInputs} from '@shared/forms/interfaces/interfaces';
-import {IDate, ITodo, Priority} from '@shared/interfacesAndTypes';
+import {IDate, ITag, ITodo, Priority} from '@shared/interfacesAndTypes';
 import {useTags} from '@entities/tag/utils/useTags';
 import TodoFormInputs from '@shared/forms/ui/Inputs';
 import FormActions from '@features/todoFeatures/components/setDataPanel';
@@ -19,6 +19,7 @@ interface Props {
   onSubmit: (newTodo: ITodo) => void,
   todo?: ITodo,
   initialDate?: string,
+  initialTag?:ITag['id'][],
   hideActions?: boolean,
   todoProjectId?: string
 }
@@ -28,6 +29,7 @@ const BaseTodoForm = ({
   onSubmit,
   todo,
   initialDate,
+  initialTag = [],
   hideActions,
   todoProjectId}: Props) => {
   const defaultInputValues = {
@@ -36,10 +38,9 @@ const BaseTodoForm = ({
   }
 
   const {control, handleSubmit, formState: {isValid}} = useForm<BaseFormInputs>({defaultValues: defaultInputValues});
-  const [formState, formDispatch] = useBaseFormReducer(todo, {todoProjectId, initialDate})
+  const [formState, formDispatch] = useBaseFormReducer(todo, {todoProjectId, initialDate, initialTag})
   const [todoTags, onSelectTag] = useTags(formState, !!todo);
   const [isDisabledAfterSubmit, setIsDisabledAfterSubmit] = useState(false)
-
 
   const setProject = (projectId: string) => {
     formDispatch(changeProjectActionCreator(projectId))

--- a/src/pages/todos/components/todo-list.tsx
+++ b/src/pages/todos/components/todo-list.tsx
@@ -16,11 +16,10 @@ interface Props {
     initialDate?: IDate,
     initialProject?: ITodo['projectId'],
     initialTag?: ITodo['tags'],
-    noAddButton?:boolean,
     children?: React.ReactElement
 }
 
-const TodoList = memo(({todos, initialDate, initialProject, noAddButton = false, children, initialTag}: Props) => {
+const TodoList = memo(({todos, initialDate, initialProject, children, initialTag}: Props) => {
   const [isOpenForm, openForm, closeForm] = useVisable(false);
   const [chosenTodos, setChosenTodos] = useState<ITodo['id'][]>([])
   const [allSelected, setAllSelected] = useState<boolean>(false)
@@ -41,7 +40,6 @@ const TodoList = memo(({todos, initialDate, initialProject, noAddButton = false,
 
   const sortedTodos = sortTodosByProperty(sorting, todos, order)
 
-
   const form = isOpenForm ? (
           <Box mt={'20px'}>
             <CreateTodoForm onClose={closeForm}
@@ -49,7 +47,7 @@ const TodoList = memo(({todos, initialDate, initialProject, noAddButton = false,
               initialTag={initialTag}
               initialProject={initialProject}/>
           </Box>
-      ) : !noAddButton && <AddTaskButton onCreate={openForm}/>
+      ) : <AddTaskButton onCreate={openForm}/>
 
   return (
     <Box mt={'20px'} paddingBottom={'20px'}>

--- a/src/pages/todos/components/todo-list.tsx
+++ b/src/pages/todos/components/todo-list.tsx
@@ -1,6 +1,6 @@
 import React, {memo, useState} from 'react';
 import {Box} from '@mui/material';
-import {IDate, ITag, ITodo} from '@shared/interfacesAndTypes';
+import {IDate, ITodo} from '@shared/interfacesAndTypes';
 import CreateTodoForm from '@features/todoFeatures/CreateTodo/components/createTodoForm';
 import AddTaskButton from '@features/todoFeatures/CreateTodo/components/AddTaskButton';
 import RenderedList from '@entities/todos/components/RenderedList/RenderedList';
@@ -14,8 +14,8 @@ import {sortTodosByProperty} from '@shared/helpers';
 interface Props {
     todos: ITodo[],
     initialDate?: IDate,
-    initialProject?: string,
-    initialTag?: ITag['id'][],
+    initialProject?: ITodo['projectId'],
+    initialTag?: ITodo['tags'],
     noAddButton?:boolean,
     children?: React.ReactElement
 }

--- a/src/pages/todos/components/todo-list.tsx
+++ b/src/pages/todos/components/todo-list.tsx
@@ -1,6 +1,6 @@
 import React, {memo, useState} from 'react';
 import {Box} from '@mui/material';
-import {IDate, ITodo} from '@shared/interfacesAndTypes';
+import {IDate, ITag, ITodo} from '@shared/interfacesAndTypes';
 import CreateTodoForm from '@features/todoFeatures/CreateTodo/components/createTodoForm';
 import AddTaskButton from '@features/todoFeatures/CreateTodo/components/AddTaskButton';
 import RenderedList from '@entities/todos/components/RenderedList/RenderedList';
@@ -15,11 +15,12 @@ interface Props {
     todos: ITodo[],
     initialDate?: IDate,
     initialProject?: string,
+    initialTag?: ITag['id'][],
     noAddButton?:boolean,
     children?: React.ReactElement
 }
 
-const TodoList = memo(({todos, initialDate, initialProject, noAddButton = false, children}: Props) => {
+const TodoList = memo(({todos, initialDate, initialProject, noAddButton = false, children, initialTag}: Props) => {
   const [isOpenForm, openForm, closeForm] = useVisable(false);
   const [chosenTodos, setChosenTodos] = useState<ITodo['id'][]>([])
   const [allSelected, setAllSelected] = useState<boolean>(false)
@@ -43,7 +44,10 @@ const TodoList = memo(({todos, initialDate, initialProject, noAddButton = false,
 
   const form = isOpenForm ? (
           <Box mt={'20px'}>
-            <CreateTodoForm onClose={closeForm} initialDate={initialDate} initialProject={initialProject}/>
+            <CreateTodoForm onClose={closeForm}
+              initialDate={initialDate}
+              initialTag={initialTag}
+              initialProject={initialProject}/>
           </Box>
       ) : !noAddButton && <AddTaskButton onCreate={openForm}/>
 

--- a/src/pages/todos/pages/FilteredByTagTodosPage/FilteredByTagTodosPage.tsx
+++ b/src/pages/todos/pages/FilteredByTagTodosPage/FilteredByTagTodosPage.tsx
@@ -14,12 +14,13 @@ const FilteredByTagTodosPage = () => {
   const tag = useTagById(id)
   const navigate = useNavigate()
 
-  if (!id) return <NoTodosWithTag/>
+  const initialTagToCreateTodo = [tag.id]
+  if (!id) return <NoTodosWithTag initialTag={initialTagToCreateTodo}/>
 
   return (
     <>
       {
-        filteredTodos.length === 0 ? <NoTodosWithTag/> :
+        filteredTodos.length === 0 ? <NoTodosWithTag initialTag={initialTagToCreateTodo}/> :
             <TodoList todos={filteredTodos} initialTag={[id]}>
               <PageTitle>
                 <Box sx={{display: 'flex', alignItems: 'center'}}>

--- a/src/pages/todos/pages/FilteredByTagTodosPage/FilteredByTagTodosPage.tsx
+++ b/src/pages/todos/pages/FilteredByTagTodosPage/FilteredByTagTodosPage.tsx
@@ -7,6 +7,7 @@ import {PageTitle, TodoList} from '@pages/todos/components';
 import NoTodosWithTag from '@pages/todos/pages/FilteredByTagTodosPage/ui/noTodosWithTag';
 import CustomIconButton from '@shared/components/CustomIconButton';
 import {TAGS_LINK} from '@shared/constants';
+import NotFound from '@pages/NotFound';
 
 const FilteredByTagTodosPage = () => {
   const {id} = useParams()
@@ -14,8 +15,9 @@ const FilteredByTagTodosPage = () => {
   const tag = useTagById(id)
   const navigate = useNavigate()
 
+  if (!id || !tag) return <NotFound/>
+
   const initialTagToCreateTodo = [tag.id]
-  if (!id) return <NoTodosWithTag initialTag={initialTagToCreateTodo}/>
 
   return (
     <>

--- a/src/pages/todos/pages/FilteredByTagTodosPage/FilteredByTagTodosPage.tsx
+++ b/src/pages/todos/pages/FilteredByTagTodosPage/FilteredByTagTodosPage.tsx
@@ -14,11 +14,13 @@ const FilteredByTagTodosPage = () => {
   const tag = useTagById(id)
   const navigate = useNavigate()
 
+  if (!id) return <NoTodosWithTag/>
+
   return (
     <>
       {
         filteredTodos.length === 0 ? <NoTodosWithTag/> :
-            <TodoList noAddButton todos={filteredTodos}>
+            <TodoList todos={filteredTodos} initialTag={[id]}>
               <PageTitle>
                 <Box sx={{display: 'flex', alignItems: 'center'}}>
                   <CustomIconButton sx={{mr: '10px'}} onClick={() => navigate('/' + TAGS_LINK)}>

--- a/src/pages/todos/pages/FilteredByTagTodosPage/ui/noTodosWithTag.tsx
+++ b/src/pages/todos/pages/FilteredByTagTodosPage/ui/noTodosWithTag.tsx
@@ -1,18 +1,37 @@
 import React from 'react';
 import {Box, Typography} from '@mui/material';
+import AddTaskButton from '@features/todoFeatures/CreateTodo/components/AddTaskButton';
+import CreateTodoForm from '@features/todoFeatures/CreateTodo/components/createTodoForm';
+import {ITodo} from '@shared/interfacesAndTypes';
+import {useVisable} from '@shared/hooks';
 
-const NoTodosWithTag = () => {
-  return <Box display={'flex'}
-    flexDirection={'column'}
-    margin={'0 auto'}
-    alignItems={'center'}
-    textAlign={'center'}>
-    <img style={{alignSelf: 'center'}}
-      src="https://todoist.b-cdn.net/assets/images/5912cb674b44ab3d789ea98c95d1cfe3.jpg" alt=""/>
-    <Typography color={'#202020'} fontWeight={700}>
-      No todos found, try adding this tag to some tasks…
-    </Typography>
-  </Box>
+interface Props {
+  initialTag?: ITodo['tags']
+}
+const NoTodosWithTag = ({initialTag}: Props) => {
+  const [isOpenForm, openForm, closeForm] = useVisable(false);
+
+  const form = (
+    <Box mt={'20px'} width={'100%'}>
+      <CreateTodoForm onClose={closeForm}
+        initialTag={initialTag}/>
+    </Box>
+  );
+
+  return isOpenForm ? form : <>
+    <Box display={'flex'}
+      flexDirection={'column'}
+      width={'100%'}
+      alignItems={'center'}
+      textAlign={'center'}>
+      <img style={{alignSelf: 'center'}}
+        src="https://todoist.b-cdn.net/assets/images/5912cb674b44ab3d789ea98c95d1cfe3.jpg" alt=""/>
+      <Typography color={'#202020'} fontWeight={700}>
+          No todos found, try adding this tag to some tasks…
+      </Typography>
+      <AddTaskButton onCreate={openForm}/>
+    </Box>
+  </>
 };
 
 export default NoTodosWithTag;

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,18 +1,16 @@
-import {Dayjs} from 'dayjs';
-import * as dayjsModule from 'dayjs';
-import dayJsDefault from 'dayjs'
+import dayjs, {Dayjs} from 'dayjs';
 
 export const dateFormat = 'MMM D';
-export const DAY_JS = process.env.NODE_ENV === 'production' ? dayJsDefault : dayjsModule
+
 export const overdueDate = (date: string): boolean => {
-  return DAY_JS(date).isBefore(DAY_JS().format(dateFormat));
+  return dayjs(date).isBefore(dayjs().format(dateFormat));
 };
 
 export const dateToFormat = (date: Dayjs) => {
   return date.format(dateFormat)
 }
 
-export const TODAY = dateToFormat(DAY_JS())
+export const TODAY = dateToFormat(dayjs())
 
 export const INBOX_LINK = 'inbox';
 export const TODAY_LINK = 'today';

--- a/src/shared/forms/hooks/useBaseFormReducer.ts
+++ b/src/shared/forms/hooks/useBaseFormReducer.ts
@@ -1,11 +1,11 @@
 import React from 'react';
-import {IDate, ITag, ITodo} from '@shared/interfacesAndTypes';
+import {IDate, ITodo} from '@shared/interfacesAndTypes';
 import {useReducer} from 'react';
 
 type Options = {
   todoProjectId?: string,
   initialDate?: string
-  initialTag: ITag['id'][]
+  initialTag: ITodo['tags'],
 }
 
 

--- a/src/shared/forms/hooks/useBaseFormReducer.ts
+++ b/src/shared/forms/hooks/useBaseFormReducer.ts
@@ -1,10 +1,11 @@
 import React from 'react';
-import {IDate, ITodo} from '@shared/interfacesAndTypes';
+import {IDate, ITag, ITodo} from '@shared/interfacesAndTypes';
 import {useReducer} from 'react';
 
 type Options = {
   todoProjectId?: string,
   initialDate?: string
+  initialTag: ITag['id'][]
 }
 
 
@@ -12,7 +13,7 @@ const initialStateFunction = (todo?: ITodo, options?: Options) => ({
   id: todo?.id || Date.now(),
   label: todo?.label || '',
   description: todo?.description || '',
-  tags: todo?.tags || [],
+  tags: todo?.tags || options?.initialTag || [],
   date: todo?.date || options?.initialDate || '',
   priority: todo?.priority || '4',
   done: todo?.done || false,

--- a/src/shared/helpers/sortTodosByProperty/sortTodosByProperty.ts
+++ b/src/shared/helpers/sortTodosByProperty/sortTodosByProperty.ts
@@ -1,6 +1,5 @@
 import {ITodo} from '@shared/interfacesAndTypes';
-import {DAY_JS} from '@shared/constants'
-
+import dayjs from 'dayjs';
 
 const sortTodosByProperty = (sortType: string, todos: ITodo[], order: string) => {
   switch (sortType) {
@@ -34,9 +33,9 @@ export default sortTodosByProperty
 
 
 const compareDates = (first: string | undefined, second: string | undefined, order: string): number => {
-  if (DAY_JS(first).isAfter(second)) {
+  if (dayjs(first).isAfter(second)) {
     return order === 'ascending' ? 1 : -1
-  } else if (DAY_JS(first).isSame(second)) {
+  } else if (dayjs(first).isSame(second)) {
     return 0
   } else return order === 'ascending' ? -1 : 1
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
@@ -24,7 +24,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
   },
   "include": ["src", "vite.config.ts"],
   "references": [{ "path": "./tsconfig.node.json" }],


### PR DESCRIPTION
Task in jira - [https://artemtuytyunik.atlassian.net/browse/TODOS-66](url)

I`ve implemented an opportunity for users to create todo from tag page. This displays the creating todo form with a tag already set from the page on which we create the task.

For this in [FilteredByTagTodosPage.tsx](https://github.com/ArtemTyutunik/TODOS/compare/development...Create_todo_with_default_tag?expand=1#diff-ed296e641e7122830dec1031bd3fcb44d17143c8ef6748ab316b2038e8f601fb)  I remove prop `noAddButton` that hides `add button`. Also now we need to pass initial tag id to `BaseTodoForm`. The type of this prop `ITodo[tags]`.


